### PR TITLE
Lógica para peso cúbico menor que 10

### DIFF
--- a/routes/ecom/modules/calculate-shipping.js
+++ b/routes/ecom/modules/calculate-shipping.js
@@ -187,7 +187,7 @@ module.exports = appSdk => {
             cubicWeight /= 6000
           }
         }
-        nVlPeso += (quantity * (cubicWeight < 10 ? physicalWeight : physicalWeight > cubicWeight ? physicalWeight : cubicWeight))
+        nVlPeso += (quantity * (cubicWeight < 5 || physicalWeight > cubicWeight ? physicalWeight : cubicWeight))
       })
 
       // pre check for maximum allowed declared value

--- a/routes/ecom/modules/calculate-shipping.js
+++ b/routes/ecom/modules/calculate-shipping.js
@@ -187,7 +187,7 @@ module.exports = appSdk => {
             cubicWeight /= 6000
           }
         }
-        nVlPeso += (quantity * (physicalWeight > cubicWeight ? physicalWeight : cubicWeight))
+        nVlPeso += (quantity * (cubicWeight < 10 ? physicalWeight : physicalWeight > cubicWeight ? physicalWeight : cubicWeight))
       })
 
       // pre check for maximum allowed declared value


### PR DESCRIPTION
Não testei, porque não consegui dar npm i no meu pc, dava erro toda hora. Mas conforme a regra ai da boxloja e de outros que vi, tem de inserir que quando o peso cúbico for menor que 10 e assim pegar o peso físico. Tivemos dois casos de duas lojas em que utilizando peso cúbico daria 1.3 e o peso físico seria 300g e a diferença de preço deu quase 9 reais.